### PR TITLE
Implement navigation bar edge-to-edge for a cleaner look

### DIFF
--- a/app/src/main/java/me/gingerninja/sample/lazylistanimations/MainActivity.kt
+++ b/app/src/main/java/me/gingerninja/sample/lazylistanimations/MainActivity.kt
@@ -13,9 +13,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -141,9 +144,9 @@ class MainActivity : ComponentActivity() {
                 ) { innerPadding ->
                     Column(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                            .padding(top = innerPadding.calculateTopPadding())
+                            .fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         SingleChoiceSegmentedButtonRow {
                             SegmentedButton(
@@ -304,7 +307,8 @@ fun AnimatedLazyColumn(
 
     LazyColumn(
         modifier = modifier,
-        state = state
+        state = state,
+        contentPadding = WindowInsets.navigationBars.asPaddingValues(),
     ) {
         itemsIndexed(items = items, key = { _, item -> item.id }) { index, item ->
             ItemCard(


### PR DESCRIPTION
Hey! I recently came across this repository and wanted to try and make use of your `AnimatedLazyColumn` and `AnimatedLazyRow` components.

I found these quite nice to work with and the animations are great! One thing I added to this while working is a full edge-to-edge rendering scheme. Items will now render under the navigation bar instead of being covered up by a solid colour. It's only a few lines of code but really improves the app's look.

| 3 Button Before | 3 Button After |
|:----------:|:-------------:|
| ![3ButtonBefore](https://github.com/gregkorossy/Sample-LazyListAnimations/assets/38306929/921851a2-0c21-493d-987a-98b7b91ad362)  | ![3ButtonAfter](https://github.com/gregkorossy/Sample-LazyListAnimations/assets/38306929/c268bc83-6721-4dbc-a0cc-87728a4aa47b) |

### The effect with gesture navigation is even more apparent: 

| Gesture Bar Before | Gesture Bar After |
|:----------:|:-------------:|
| ![GestureBefore](https://github.com/gregkorossy/Sample-LazyListAnimations/assets/38306929/fde63240-8527-49cb-80da-2b44ac71c94e) | ![GestureAfter](https://github.com/gregkorossy/Sample-LazyListAnimations/assets/38306929/da95e79a-6e46-43a7-8035-74db884f95d3) |


With gesture navigation enabled, an entire next card is visible.

For the appearance of the app, can this be merged?